### PR TITLE
Provides a version instead of inheriting from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
   <groupId>gov.nasa.pds.2010.search</groupId>
   <artifactId>search-ui</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <name>Search User Interface</name>


### PR DESCRIPTION
## 🗒️ Summary

Provides a version instead of inheriting from parent pom. This is so we can Roundup tag/automate releases/artifacts.

## ⚙️ Test Data and/or Report
```console
$ ls target
ls: target: No such file or directory
$ egrep '<version>.*SNAPSHOT' pom.xml
  <version>2.0.0-SNAPSHOT</version>
$ mvn package
…
$ ls -1dF target/*-SNAPSHOT*
target/search-ui-2.0.0-SNAPSHOT/
target/search-ui-2.0.0-SNAPSHOT-bin.tar.gz
target/search-ui-2.0.0-SNAPSHOT-bin.zip
```
## ♻️ Related Issues

- #1 
