### PR TITLE
Add null check to response header method

### DIFF
--- a/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
+++ b/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
@@ -114,6 +114,7 @@ public class RegistryLegacyServlet extends HttpServlet {
       response.getOutputStream().write(solrResponse.body().getBytes());
     } catch (Exception e) {
       LOG.severe(e.getMessage());
+      e.printStackTrace();
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
     }
   }
@@ -161,12 +162,13 @@ public class RegistryLegacyServlet extends HttpServlet {
 
   private void setResponseHeader(String wt, HttpServletResponse response) {
     String contentType = "text/html; charset=UTF-8";
-    if (wt.equals("json")) {
-      contentType = "application/json; charset=UTF-8";
-    } else if (wt.equals("xml")) {
-      contentType = "application/xml; charset=UTF-8";
+    if (wt != null) {
+      if (wt.equals("json")) {
+        contentType = "application/json; charset=UTF-8";
+      } else if (wt.equals("xml")) {
+        contentType = "application/xml; charset=UTF-8";
+      }
     }
-    
     response.addHeader(HttpHeaders.CONTENT_TYPE, contentType);
   }
 }


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Fix issues with nullpointerexception

## ⚙️ Test Data and/or Report
* Load any documents into your registry.
* Run curl command
```
$ curl --GET http://localhost:8080/search-ui-legacy/search?q=*:*


<div xmlns:html="http://www.w3.org/1999/xhtml" id="sidebar">
   <div class="sidebarSection">
      <h2>Refine Your Search</h2>
      <h3>
         <span class="pds_value">Type</span>
      </h3>
      <ul>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_type%3A%221%2Ccollection%22&amp;f.facet_type.facet.prefix=2%2Ccollection%2C">collection</a> (3661)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_type%3A%221%2Cbundle%22&amp;f.facet_type.facet.prefix=2%2Cbundle%2C">bundle</a> (557)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_type%3A%221%2Cdocument%22&amp;f.facet_type.facet.prefix=2%2Cdocument%2C">document</a> (45)</li>
      </ul>
      <h3>
         <span class="pds_value">Target</span>
      </h3>
      <ul>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Cplanet%22&amp;f.facet_target.facet.prefix=2%2Cplanet%2C">planet</a> (1581)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Csatellite%22&amp;f.facet_target.facet.prefix=2%2Csatellite%2C">satellite</a> (460)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Cother%22&amp;f.facet_target.facet.prefix=2%2Cother%2C">other</a> (262)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Ccalibration%22&amp;f.facet_target.facet.prefix=2%2Ccalibration%2C">calibration</a> (65)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Cring%22&amp;f.facet_target.facet.prefix=2%2Cring%2C">ring</a> (57)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Casteroid%22&amp;f.facet_target.facet.prefix=2%2Casteroid%2C">asteroid</a> (48)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Ccomet%22&amp;f.facet_target.facet.prefix=2%2Ccomet%2C">comet</a> (3)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Cmeteorite%22&amp;f.facet_target.facet.prefix=2%2Cmeteorite%2C">meteorite</a> (3)</li>
         <li>
            <a class="pds_value"
               href="?q=%2A%3A%2A&amp;fq=facet_target%3A%221%2Ctrans-neptunian%20object%22&amp;f.facet_target.facet.prefix=2%2Ctrans-neptunian%20object%2C">trans-neptunian object</a> (3)</li>
      </ul>
      <h3>
         <span class="pds_value">Investigation</span>
...
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #7 


Note: I know `Exception e` is very very bad for exception handling, but leaving for now.
