### PR TITLE
Better handling of exceptions, Fix resource leaks, Improve thread safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ src/test/temp/
 *.sublime-*
 *.DS_Store
 pom.xml.versionsBackup
+.vscode/
 
 # Java stuff
 *.javac

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2,6 +2,9 @@
   "version": "1.4.0",
   "plugins_used": [
     {
+      "name": "AbsolutePathDetectorExperimental"
+    },
+    {
       "name": "ArtifactoryDetector"
     },
     {
@@ -152,7 +155,7 @@
         "filename": "src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java",
         "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "is_secret": false
       }
     ],
@@ -219,5 +222,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-29T18:42:27Z"
+  "generated_at": "2025-04-29T19:04:22Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,7 +128,13 @@
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
         "\\.secrets..*",
-        "target"
+        "target",
+        ".*\\.tfstate",
+        ".*\\.tfstate.*",
+        ".*\\.tfvars",
+        ".*\\.terraform",
+        ".*\\.terraformrc",
+        ".*\\terraform.rc"
       ]
     }
   ],
@@ -149,7 +155,7 @@
         "filename": "src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java",
         "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
         "is_verified": false,
-        "line_number": 131,
+        "line_number": 125,
         "is_secret": false
       }
     ],
@@ -216,5 +222,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-17T18:40:21Z"
+  "generated_at": "2025-04-29T17:29:57Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": "src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java",
         "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 172,
         "is_secret": false
       }
     ],
@@ -222,5 +222,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-29T19:04:22Z"
+  "generated_at": "2025-05-01T23:13:28Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2,9 +2,6 @@
   "version": "1.4.0",
   "plugins_used": [
     {
-      "name": "AbsolutePathDetectorExperimental"
-    },
-    {
       "name": "ArtifactoryDetector"
     },
     {
@@ -155,7 +152,7 @@
         "filename": "src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java",
         "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 176,
         "is_secret": false
       }
     ],
@@ -222,5 +219,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-29T17:29:57Z"
+  "generated_at": "2025-04-29T18:42:27Z"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -131,10 +131,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-	    <groupId>org.apache.httpcomponents.client5</groupId>
-	    <artifactId>httpclient5</artifactId>
-	    <version>5.4.1</version>
-	</dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.4.1</version>
+        <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <!-- Project Information and Reports inherited from parent. -->

--- a/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
+++ b/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
@@ -219,7 +219,7 @@ public class RegistryLegacyServlet extends HttpServlet {
    * @throws UnsupportedEncodingException
    */
   private String getQueryString(HttpServletRequest request) {
-    String queryString = "";
+    StringBuilder queryString = new StringBuilder();
 
     try {
       Enumeration<?> parameterNames = request.getParameterNames();
@@ -233,10 +233,10 @@ public class RegistryLegacyServlet extends HttpServlet {
             this.solrRequestHandler = value;
           }
         } else if (SOLR_QUERY_PARAMS.contains(paramKey)) {
-          queryString += appendQueryParameters(paramKey, request.getParameterValues(paramKey));
+          queryString.append(appendQueryParameters(paramKey, request.getParameterValues(paramKey)));
         } else if (paramKey.endsWith(".facet.prefix")
             && SOLR_FACET_FIELDS.contains(paramKey.split("\\.")[1])) {
-          queryString += appendQueryParameters(paramKey, request.getParameterValues(paramKey));
+          queryString.append(appendQueryParameters(paramKey, request.getParameterValues(paramKey)));
         } else {
           if (LOG.isWarnEnabled()) {
             LOG.warn("Unknown parameter: {}", URLEncoder.encode(XssUtils.sanitize(paramKey), "UTF-8"));
@@ -244,13 +244,13 @@ public class RegistryLegacyServlet extends HttpServlet {
         }
       }
 
-      if (queryString.equals("")) {
-        queryString = "q=*:*";
+      if (queryString.length() == 0) {
+        queryString.append("q=*:*");
       }
 
       LOG.info("Solr query: {}", queryString);
 
-      return queryString;
+      return queryString.toString();
     } catch (UnsupportedEncodingException e) {
       LOG.error("Error encoding query parameters", e);
       return "q=*:*";
@@ -258,14 +258,13 @@ public class RegistryLegacyServlet extends HttpServlet {
   }
 
   private String appendQueryParameters(String key, String[] parameterValues) {
-    String value = "";
-    String queryString = "";
+    StringBuilder queryString = new StringBuilder();
     try {
       for (String v : Arrays.asList(parameterValues)) {
-        value = XssUtils.sanitize(v);
-        queryString += String.format("%s=%s&", key, URLEncoder.encode(value, "UTF-8"));
+        String value = XssUtils.sanitize(v);
+        queryString.append(String.format("%s=%s&", key, URLEncoder.encode(value, "UTF-8")));
       }
-      return queryString;
+      return queryString.toString();
     } catch (UnsupportedEncodingException e) {
       LOG.error("Error encoding parameter value", e);
       return "";

--- a/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
+++ b/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
@@ -251,7 +251,7 @@ public class RegistryLegacyServlet extends HttpServlet {
     try {
       for (String v : Arrays.asList(parameterValues)) {
         LOG.info("{} : {}", key, v);
-        value = XssUtils.clean(v);
+        value = XssUtils.sanitize(v);
         queryString += String.format("%s=%s&", key, URLEncoder.encode(value, "UTF-8"));
       }
       return queryString;

--- a/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
+++ b/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
@@ -27,8 +27,6 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.apache.hc.client5.http.config.RequestConfig;
-import java.util.concurrent.TimeUnit;
-import java.time.Duration;
 import java.io.PrintWriter;
 
 
@@ -169,6 +167,9 @@ public class RegistryLegacyServlet extends HttpServlet {
           writer.write(resultContent);
         }
       }
+    } catch (IOException e) {
+      LOG.error("Error processing request", e);
+    }
     } catch (Exception e) {
       LOG.error("Error processing request", e);
       try {

--- a/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
+++ b/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
@@ -262,7 +262,6 @@ public class RegistryLegacyServlet extends HttpServlet {
     String queryString = "";
     try {
       for (String v : Arrays.asList(parameterValues)) {
-        LOG.info("{} : {}", key, v);
         value = XssUtils.sanitize(v);
         queryString += String.format("%s=%s&", key, URLEncoder.encode(value, "UTF-8"));
       }

--- a/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
+++ b/src/main/java/gov/nasa/pds/search/servlet/RegistryLegacyServlet.java
@@ -226,7 +226,9 @@ public class RegistryLegacyServlet extends HttpServlet {
             && SOLR_FACET_FIELDS.contains(paramKey.split("\\.")[1])) {
           queryString += appendQueryParameters(paramKey, request.getParameterValues(paramKey));
         } else {
-          LOG.warn("Unknown parameter: {}", URLEncoder.encode(XssUtils.clean(paramKey), "UTF-8"));
+          if (LOG.isWarnEnabled()) {
+            LOG.warn("Unknown parameter: {}", URLEncoder.encode(XssUtils.clean(paramKey), "UTF-8"));
+          }
         }
       }
 

--- a/src/main/java/gov/nasa/pds/search/util/XssUtils.java
+++ b/src/main/java/gov/nasa/pds/search/util/XssUtils.java
@@ -41,7 +41,7 @@ public class XssUtils {
      * 
      * @throws UnsupportedEncodingException
      */
-    public static String clean(String value) throws UnsupportedEncodingException {
+    public static String sanitize(String value) throws UnsupportedEncodingException {
 		if (value != null) {
 			// Avoid null characters
 		    value = URLDecoder.decode(value, "UTF-8");


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
- No longer throw exceptions within the servlet
- Replace volatile field with AtomicReference for thread-safe initialization
- Add proper cleanup method to replace finalize()
- Fix resource leaks in HTTP client handling
- Improve error handling and logging
- Add proper connection pool configuration
- Fix connection eviction policy

## ⚙️ Test Data and/or Report
* Deployed search-ui-legacy on staging
* Spot checked various searches on staging and MCP sites
* Spot checked ds-view for each context product and data landing pages

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
refs https://github.com/NASA-PDS/ds-view/issues/14
resolves #49
