### PR TITLE
Updated parent POM to take advantage of new Central Repo Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">  
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>gov.nasa</groupId>
-    <artifactId>pds</artifactId>
-    <version>1.18.0</version>
+    <groupId>gov.nasa.pds</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.19.0</version>
   </parent>
 
   <groupId>gov.nasa.pds.2010.search</groupId>


### PR DESCRIPTION
## 🗒️ Summary

The older [OSSRH is being decommissioned in favor of the new Maven Central Repository Portal](https://github.com/NASA-PDS/software-issues-repo/issues/128). The parent POM now takes advantage of it and has been published.

For this repository to do the same, it must inherit from the new parent POM. Merge this to achieve that.

## ⚙️ Test Data and/or Report

Not applicable; however any checks that fail below are likely orthogonal to this change.

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128
- https://github.com/NASA-PDS/software-issues-repo/issues/131
